### PR TITLE
Fix discord bot indentation error

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -575,6 +575,7 @@ async def casino_info(interaction: discord.Interaction):
             daily_limit = DailyCasinoLimit.query.filter_by(user_id=user_id).first()
             # Only show daily limit info if it's for today
             if daily_limit and daily_limit.date == datetime.utcnow().date():
+                pass  # This condition is handled later in the embed creation
 
             embed = discord.Embed(
                 title="🎰 Casino Information",


### PR DESCRIPTION
Fix `IndentationError` in `casino_info` by adding a `pass` statement to an incomplete `if` block.

The `if` statement on line 577 was missing its body, causing the subsequent embed creation to be incorrectly flagged as an indentation error. Adding `pass` resolves the syntax error, as the condition's logic is already handled later when populating the embed fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0bc3c9e-6761-4364-9df6-1c2879e608b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0bc3c9e-6761-4364-9df6-1c2879e608b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

